### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Add the following to `application.scss`
 
 `@import "tempusdominus-bootstrap-4";`
 
+Or
+
+`*= require tempusdominus-bootstrap-4`
+
 ## Localizations
 
 The Tempus Dominus datepicker exposes Moment.js localizations. A list of available Moment localizations are found [here](https://github.com/moment/moment/tree/master/locale).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to `application.js`
 
 Add the following to `application.scss`
 
-`@import "tempusdominus-bootstrap-4.css";`
+`@import "tempusdominus-bootstrap-4";`
 
 ## Localizations
 


### PR DESCRIPTION
`@import "tempusdominus-bootstrap-4.css";` does not work on heroku. But without the extension, it works fine: `@import "tempusdominus-bootstrap-4";`