### PR TITLE
Dependency Updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,12 +12,25 @@ Add the following to `application.js`
 
 ```
 //= require moment
-//= require tempusdominus-bootstrap-4.js
+// If you require timezone data (see moment-timezone-rails for additional file options)
+//= require moment-timezone-with-data
+//= require tempusdominus-bootstrap-4
 ```
 
 Add the following to `application.scss`
 
 `@import "tempusdominus-bootstrap-4.css";`
+
+
+If you are not using Sass, add the following to your `application.css`
+
+```
+/*
+...
+*= require tempusdominus-bootstrap-4
+...
+*/
+```
 
 ## Localizations
 

--- a/bootstrap4_datetime_picker_rails.gemspec
+++ b/bootstrap4_datetime_picker_rails.gemspec
@@ -12,8 +12,9 @@ Gem::Specification.new do |gem|
   gem.name          = 'bootstrap4-datetime-picker-rails'
   gem.require_path  = 'lib'
   gem.version       = Bootstrap4DatetimePickerRails::Rails::VERSION
-  gem.files         = Dir['README.md', "{lib,vendor}/**/*"]
-  gem.add_dependency 'momentjs-rails', '~> 2.10', '>= 2.10.5'
+  gem.files         = Dir['README.md', "{lib,vendor}/**/*", 'LICENSE']
+  gem.add_dependency 'momentjs-rails', '>= 2.10.5', '<= 3.0.0'
+  gem.add_dependency 'moment-timezone-rails', '~> 1.0', '<= 2.0.0'
   gem.add_dependency 'jquery-rails', '~> 4.2', '>= 4.2.0'
   gem.add_development_dependency 'bundler', '~> 1.16', '>= 1.16.0'
   gem.add_development_dependency 'json', '~> 2.1', ' >= 2.1.0'

--- a/lib/bootstrap4_datetime_picker_rails/engine.rb
+++ b/lib/bootstrap4_datetime_picker_rails/engine.rb
@@ -1,6 +1,12 @@
+require 'momentjs-rails'
+require 'moment-timezone-rails'
+
 module Bootstrap4DatetimePickerRails
   module Rails
     class Engine < ::Rails::Engine
+      initializer 'bootstrap-4-datetime-picker-rails.assets.precompile' do |app|
+        app.config.assets.precompile += %w[tempusdominus-bootstrap-4.js]
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request changes the moment-timezone dependency to my own `moment-timezone-rails` gem. I'm making this change because I want to avoid consuming projects needing to include a dependency of this gem in their Gemfile (so that it is `require`'d when Rails starts). To this end, I am also  adding `require` statements for dependencies that are not by Rails already (i.e. `jquery-rails`) in `engine.rb` which looks to be an acceptable pattern.

This patch also includes the MIT license distributed with the Gem.

This patch also fixes the `momentjs-rails` version to the Tempus Dominus required versions. `momentjs-rails` has historically tracked the actual JavaScript libraries version.